### PR TITLE
adding ability to pass options to mongodb find

### DIFF
--- a/src/mongo-client.js
+++ b/src/mongo-client.js
@@ -14,7 +14,7 @@ class MongoClient {
         } else {
           try {
             const collection = client.db().collection(parameters.collection);
-            const cursor = collection.find(parameters.find || {});
+            const cursor = collection.find(parameters.find || {}, parameters.options || {});
             const transformer = new MongoToGrpcTransformer(call);
             transformer.pipe(call);
             cursor.pipe(transformer);


### PR DESCRIPTION
The MongoDb driver for Node.js has a second parameter `options` for the `find` function.

[Documentation Here](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find)

The object lets the developer specify options like projection to limit which fields are returned. This PR allows for the ability to pass an `options` parameter to the connector which will be forwarded to the mongo client.