### PR TITLE
Added code to close the client when the cursor is closed

### DIFF
--- a/src/mongo-client.js
+++ b/src/mongo-client.js
@@ -15,6 +15,10 @@ class MongoClient {
           try {
             const collection = client.db().collection(parameters.collection);
             const cursor = collection.find(parameters.find || {}, parameters.options || {});
+            cursor.on('close', () => {
+              // we need to close the connection
+              client.close();
+            });
             const transformer = new MongoToGrpcTransformer(call, parameters.booleanType);
             transformer.pipe(call);
             cursor.pipe(transformer);


### PR DESCRIPTION
When attempting to set up a constant reload my mongodb ended up with thousands of connections, which would make sense since there's nothing in the code to close the connection. This commit will close the connection to mongo once the cursor is closed