### PR TITLE
Implementation of #75

### DIFF
--- a/src/mongo-client.js
+++ b/src/mongo-client.js
@@ -19,7 +19,7 @@ class MongoClient {
               // we need to close the connection
               client.close();
             });
-            const transformer = new MongoToGrpcTransformer(call, parameters.booleanType);
+            const transformer = new MongoToGrpcTransformer(call, parameters.booleanType, parameters.options ? parameters.options.projection : null);
             transformer.pipe(call);
             cursor.pipe(transformer);
           } catch (error) {


### PR DESCRIPTION
as described previously, the projection is passed through to the transformer (if available), the transformer will use the projection to build the field list if provided, otherwise it will refer to the chunk as usual. This commit also does a check to see if the header was sent when flushing so the load script won't crash on an empty dataset.